### PR TITLE
introduce m-let

### DIFF
--- a/src/io/github/gaverhae/clonad.clj
+++ b/src/io/github/gaverhae/clonad.clj
@@ -54,16 +54,33 @@
         :else (build-monadic-value nil (cons a bindings-or-statements))))
 
 (defn return
-  ([v] [:pure v])
-  ([kw v] [(keyword (name kw) "pure") v]))
+  ([v] (return nil v))
+  ([kw v] [(if (nil? kw) :pure (keyword (name kw) "pure")) v]))
+
+(def pure return)
+
+(defn build-m-let
+  [kw bindings ret]
+  (cond (empty? bindings) ret
+        (>= (count bindings) 2) (let [[binding-form expr & bindings] bindings]
+                                  [(cond (nil? kw) :bind
+                                         (keyword? kw) (keyword (name kw) "bind")
+                                         :else `(if (nil? ~kw) :bind (keyword (name ~kw) "bind")))
+                                   expr
+                                   `(fn [~binding-form] ~(build-m-let kw bindings ret))])
+        :else (throw (ex-info "m-let bindings requires even number of forms" {}))))
+
+(defmacro m-let
+  ([bindings ret] `(m-let nil ~bindings ~ret))
+  ([kw bindings ret] (build-m-let kw bindings ret)))
 
 (defn m-seq
   "[m v] -> m [v]"
-  ([mvs] (m-seq (keyword nil "") mvs))
+  ([mvs] (m-seq nil mvs))
   ([prefix mvs]
    (if (empty? mvs)
      (return prefix ())
-     (monad prefix
-       v :<< (first mvs)
-       r :<< (m-seq prefix (rest mvs))
+     (m-let prefix
+       [v (first mvs)
+        r (m-seq prefix (rest mvs))]
        (return prefix (cons v r))))))

--- a/test/io/github/gaverhae/clonad_test.clj
+++ b/test/io/github/gaverhae/clonad_test.clj
@@ -38,7 +38,7 @@
               a :<< [:m/pure 3]
               b :<< [:m/pure 4]
               [:m/pure (* a b)]))))
-  #_(is (= 10
+  (is (= 10
          (run-plain-m
            (monad :m
              values :<< (t/m-seq :m [[:m/pure 1] [:m/pure 2] [:m/pure 3] [:m/pure 4]])


### PR DESCRIPTION
So I actually got a bit stuck with the syntax I was going for here.

Here's the issue. I want to be able to namespace my monadic operations, which means I need the `monad` macro to know it needs to output `:m/bind` instead of `:bind`. That's relatviely easy to do, and working in the current state of this code.

At least, as long as the provided keyword representing the namespace is a literal keyword. So, this works:

```clojure
(monad :m
  a :<< some-expr
  b :<< other-expr
  [:m/pure (+ a b)])
```

with the glue being `:m/bind`. But, I also want to be able to write generic monadic operations, like `m-seq`. Which means that now `m-seq` needs to know about the prefix. But `m-seq` is a function, and I'd prefer if it could remain that way, because macros are bad (as we see here, they tend to be contagious).

But that means I'm ultimately reduced to writing something like:

```clojure
(let [prefix :m]
  (monad prefix
    a :<< expr
    ...))
```

and that no longer works, because now when `monad` looks at its first argument it no longer sees a keyword.

Because the syntax around `monad` is so loose, I can't think of a good way for it to detect that the first argument is meant as a prefix in the general case where it is not a literal keyword. We could go down the path of making it a mandatory argument, but I don't really like that: people should be able to still use unqualified keywords if they like.

We could give it more structure, for example, define the syntax as:

```clojure
(monad [:prefix :m]
  a :<< expr
  b :<< other-expr
  ...)
```

and that would work, but it feels icky. Also we'd probably want to make it `{:prefix :m}` instead, in case we come up with other options in the future. But then we again have a map that needs to be literal, and that's annoying.

The core issue is that `monad` takes all of its arguments as a flat list, and "counts" them to find the pieces. And a single expression is a valid piece, so there's no way for us to make a distinction between a single piece meant as a monadic operation and a single piece meant as the prefix.

So I'm changing syntax again, I think. Having used monad a bit, I kinda like `:<<`, but it's not very Clojure-y. I think I'm going to move back a bit towards `mdo`, but with a tweak. Stay tuned in next PR.

To be clear, what's broken in the first commit of this PR is, specifically, `m-seq` in the presence of a keyword, as it is unable to forward it through to nested `monad` calls.

I believe `m-let` solves the keyword issue. It's also quite a bit simpler than `monad` in its implementation, and somewhat closer to Clojure `let`.

I'm leaving the other ones in this PR to offer an upgrade path, but I think `m-let` syntax subsumes both `mdo` and `monad`.